### PR TITLE
[Del] 이메일 중복 확인 API 제거 및 회원가입 로직으로 통합

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -36,11 +36,6 @@ class SignupSerializer(serializers.ModelSerializer):
         return user
 
 
-class CheckEmailQuerySerializer(serializers.Serializer):
-    """ /auth/check-email/?email=... 파싱용 """
-    email = serializers.EmailField()
-
-
 class LoginSerializer(serializers.Serializer):
     """ 로그인 입력 검증용 """
     email = serializers.EmailField()

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,9 +1,8 @@
 from django.urls import path
-from .views import SignupView, CheckEmailView, LoginView, LogoutView, MeView, WalletHistoryView
+from .views import SignupView, LoginView, LogoutView, MeView, WalletHistoryView
 
 urlpatterns = [
     path("auth/signup/", SignupView.as_view()),
-    path("auth/check-email/", CheckEmailView.as_view()),
     path("auth/login/", LoginView.as_view()),
     path("auth/logout/", LogoutView.as_view()),
     path("users/me/", MeView.as_view()),

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -4,11 +4,9 @@ from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from rest_framework import status
-from django.core.validators import validate_email
-from django.core.exceptions import ValidationError as DjangoValidationError
 
 from .serializers import (
-    SignupSerializer, CheckEmailQuerySerializer,
+    SignupSerializer,
     LoginSerializer, MeSerializer, PointHistorySerializer,
 )
 from .selectors import is_email_taken, select_wallet_history
@@ -42,26 +40,6 @@ class SignupView(APIView):
             "created_at": user.created_at.isoformat().replace("+00:00", "Z") if user.created_at else None,
         }
         return Response(body, status=status.HTTP_201_CREATED)
-
-
-class CheckEmailView(APIView):
-    permission_classes = [AllowAny]
-
-    def get(self, request):
-        q = CheckEmailQuerySerializer(data=request.query_params)
-        q.is_valid(raise_exception=True)
-        email = q.validated_data["email"]
-        try:
-            validate_email(email)
-        except DjangoValidationError:
-            return Response(
-                {"code": "INVALID_EMAIL", "message": "이메일 형식이 잘못되었습니다."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        taken = is_email_taken(email)
-        msg = "해당 이메일의 계정이 이미 존재합니다." if taken else "사용 가능한 이메일입니다."
-        return Response({"email": email, "available": (not taken), "message": msg}, status=200)
 
 
 class LoginView(APIView):


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #26

### ✨️ 작업 내용

- `/auth/signup/`에서 선제 중복검사 + DB unique로 이미 보장
- `/auth/check-email/` 폐기
- /auth/signup/의 409 EMAIL_TAKEN 동작 재확인 테스트

### 💭 코멘트

API 명세서에서 폐기 처리 하였습니다.

### 📸 구현 결과

<img width="1222" height="870" alt="image" src="https://github.com/user-attachments/assets/6f3cae51-f7e0-4f12-abad-fb314da21106" />