### PR TITLE
[feat] 챌린지 종료 기능 구현

### DIFF
--- a/challenges/serializers.py
+++ b/challenges/serializers.py
@@ -360,3 +360,17 @@ class ChallengeJoinOutSerializer(serializers.Serializer):
     entry_fee_charged = serializers.IntegerField()
     user_point_balance_after = serializers.IntegerField()
     message = serializers.CharField()
+
+
+
+# 챌린지 종료 응답용 시리얼라이저
+class ChallengeSettlementInfoSerializer(serializers.Serializer):
+    scheduled_at = serializers.DateTimeField()
+    status = serializers.CharField()
+
+
+class ChallengeEndResponseSerializer(serializers.Serializer):
+    challenge_id = serializers.IntegerField()
+    status = serializers.CharField()
+    ended_at = serializers.DateTimeField()
+    settlement = ChallengeSettlementInfoSerializer()

--- a/challenges/urls.py
+++ b/challenges/urls.py
@@ -1,4 +1,5 @@
-# challenges/urls.py
+from tkinter.font import names
+
 from django.urls import path
 from .views import *
 
@@ -6,7 +7,7 @@ from .views import (
     ChallengeListCreateView,
     MyChallengeListView, MyCompletedChallengeListView,
     ChallengeDetailView, CompleteImageDetailView, CommentCreateView,
-    ChallengeImageListView, ChallengeJoinView
+    ChallengeImageListView, ChallengeJoinView, ChallengeEndView,
 )
 
 
@@ -26,4 +27,6 @@ urlpatterns = [
     path("<int:challenge_id>/join", ChallengeJoinView.as_view(), name="challenge-join"), # POST
     
     path("<int:challenge_id>/albums/", ChallengeImageListView.as_view()),
+
+    path("<int:challenge_id>/end/", ChallengeEndView.as_view(), name="challenge-end"),
 ]

--- a/challenges/views.py
+++ b/challenges/views.py
@@ -26,6 +26,8 @@ from .serializers import (
 
     ChallengeJoinSerializer,
     ChallengeJoinOutSerializer,
+
+    ChallengeEndResponseSerializer,
 )
 from .selectors import (
     get_complete_image_with_comments,
@@ -34,7 +36,7 @@ from .selectors import (
     my_challenges_selector,
     challenge_detail_selector,
 )
-from .services import create_comment, join_challenge, Conflict
+from .services import create_comment, join_challenge, Conflict, end_challenge
 DEFAULT_DISPLAY_THUMBNAIL = getattr(settings, "DEFAULT_DISPLAY_THUMBNAIL", None)
 
 
@@ -396,3 +398,21 @@ class ChallengeJoinView(APIView):
         # 3) 응답 시리얼라이징 + 200
         out_ser = ChallengeJoinOutSerializer(payload)
         return Response(out_ser.data, status=status.HTTP_200_OK)
+
+
+
+
+class ChallengeEndView(APIView):
+    """
+    POST /challenges/{challenge_id}/end
+
+    - 챌린지 생성자 또는 운영자만 호출 가능
+    - 챌린지 상태를 ended 로 변경
+    - 정산 예약 정보(scheduled_at, status)를 함께 응답
+    """
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, challenge_id: int):
+        payload = end_challenge(user=request.user, challenge_id=challenge_id)
+        serializer = ChallengeEndResponseSerializer(payload)
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #36 

### ✨️ 작업 내용

- POST /challenges/{challenge_id}/end 엔드포인트 추가
- 챌린지 종료 비즈니스 로직(end_challenge) 구현
- status를 "ended"로 변경
- 종료 시각(ended_at) 기록
- 정산 스케줄(settlement.scheduled_at) 자동 계산 및 응답 포함
- ChallengeEndResponseSerializer, ChallengeEndView 추가
- 종료 권한 및 중복 종료 예외 처리

### 💭 코멘트

현재는 수동 종료 방식(요청 기반)으로 구현되어 있음

### 📸 구현 결과

아래는 실행 결과 화면, 200 정상 응답
<img width="1582" height="811" alt="image" src="https://github.com/user-attachments/assets/ac92c249-0490-4caf-a809-32d3998a3963" />

어드민으로 접속해서 챌린지들을 살펴보면 상태가 ended인걸 확인 할 수 있음
<img width="915" height="338" alt="image" src="https://github.com/user-attachments/assets/5ab858eb-2a40-49ea-aa92-48de2ebac019" />

이미 종료된 챌린지에 대해서는 올바른 400 Bad Request에러 응답
<img width="1579" height="717" alt="image" src="https://github.com/user-attachments/assets/d5c65b23-5d94-48ac-843a-f2d52320a40f" />

