### PR TITLE
Feat: 충전 API 구현 (#38)

### DIFF
--- a/settlements/urls.py
+++ b/settlements/urls.py
@@ -1,7 +1,10 @@
 from django.urls import path
-from .views import RewardStatusView, RewardClaimView
+from .views import RewardStatusView, RewardClaimView, WalletChargeView
 
 urlpatterns = [
     path("<int:challenge_id>/rewards", RewardStatusView.as_view()),
     path("<int:challenge_id>/rewards/claim", RewardClaimView.as_view()),
+
+    # 지갑 충전
+    path("wallet/charge", WalletChargeView.as_view()),
 ]


### PR DESCRIPTION

### 📑 이슈 번호

- close #38 

### ✨️ 작업 내용

- POST /challenges/wallet/charge API 구현
- 로그인한 사용자의 포인트 충전 기능 추가
- PointHistory에 type="charge"로 기록되고 User.point_balance 업데이트
- 정상 충전 시 201 응답 및 충전 내역 반환

### 💭 코멘트

현재  충전 시 요청 바디 보내면 +10,000 누적 충전 동작 확인 완료
그러나 api 명세서와 피그마 디자인화면에 설명과 충전 단위가 달라서 논의 필요 -> 동작에는 큰 문제 없음

### 📸 구현 결과

<img width="1919" height="1024" alt="image" src="https://github.com/user-attachments/assets/86f649ea-0e68-4ec1-9937-a4805e273faf" />
