### PR TITLE
[Feat] 챌린지 인증 조건 수정 기능 추가

### DIFF
--- a/challenges/urls.py
+++ b/challenges/urls.py
@@ -28,5 +28,7 @@ urlpatterns = [
     
     path("<int:challenge_id>/albums/", ChallengeImageListView.as_view()),
 
+    path("<int:challenge_id>/rules", ChallengeRuleUpdateView.as_view(), name="challenge-rule-update"),
+
     path("<int:challenge_id>/end/", ChallengeEndView.as_view(), name="challenge-end"),
 ]


### PR DESCRIPTION

### 📑 이슈 번호

- close #43 

### ✨️ 작업 내용

- PATCH /challenges/{challenge_id}/rules 엔드포인트 추가
- 챌린지 생성자(owner) 또는 role='owner'인 멤버만 수정 가능하도록 권한 설정
- freq_type, freq_n_days, ai_condition_text 부분 업데이트 기능 구현
- 이미 종료된 챌린지(status='ended')의 수정 요청 시 409 Conflict 반환

### 💭 코멘트


### 📸 구현 결과

<img width="1578" height="803" alt="image" src="https://github.com/user-attachments/assets/3a23ad95-b482-40c1-abf7-3d112d946129" />

<img width="1583" height="794" alt="image" src="https://github.com/user-attachments/assets/316e7a1e-0d92-4a47-9dc3-24b8b96af784" />

<img width="1582" height="718" alt="image" src="https://github.com/user-attachments/assets/766f5456-d081-4760-ae0a-5d36b4abfaa3" />
