### PR TITLE
[Feat] 초대코드 입력 검증 API 구현

### DIFF
--- a/challenges/serializers.py
+++ b/challenges/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import CompleteImage, Comment, Challenge, ChallengeCategory
+from .models import CompleteImage, Comment, Challenge, ChallengeCategory,InviteCode
 
 from django.utils.translation import gettext_lazy as _
 
@@ -504,3 +504,44 @@ class ChallengeRuleUpdateOutSerializer(serializers.Serializer):
     freq_n_days = serializers.IntegerField(allow_null=True)
     ai_condition_text = serializers.CharField()
     updated_at = serializers.DateTimeField()
+
+
+
+class InviteCodeJoinInSerializer(serializers.Serializer):
+    """
+    POST /invites/join 요청용 입력 스키마
+    {
+      "invite_code": "challink_XXXXXX"
+    }
+    """
+    invite_code = serializers.CharField()
+
+    def validate_invite_code(self, value):
+        code = value.strip()
+        if not code:
+            raise serializers.ValidationError("invite_code는 비어 있을 수 없습니다.")
+        return code
+
+
+class InviteCodeJoinOutSerializer(serializers.Serializer):
+    """
+    초대코드 검증 결과 응답 스키마
+    - 이미 참여: 최소 정보 + already_joined, can_join, message
+    - 아직 미참여: 챌린지 상세 정보 + already_joined, can_join, message
+    """
+    challenge_id = serializers.IntegerField()
+    challenge_title = serializers.CharField()
+    challenge_description = serializers.CharField(required=False, allow_blank=True)
+    entry_fee = serializers.IntegerField(required=False)
+    duration_weeks = serializers.IntegerField(required=False)
+    freq_type = serializers.CharField(required=False, allow_null=True)
+    freq_n_days = serializers.IntegerField(required=False, allow_null=True)
+    ai_condition_text = serializers.CharField(required=False, allow_blank=True)
+    settlement_method = serializers.CharField(required=False)
+    start_date = serializers.DateField(required=False, allow_null=True)
+    end_date = serializers.DateField(required=False, allow_null=True)
+
+    already_joined = serializers.BooleanField()
+    can_join = serializers.BooleanField()
+    challenge_member_id = serializers.IntegerField(required=False, allow_null=True)
+    message = serializers.CharField()

--- a/project/urls.py
+++ b/project/urls.py
@@ -18,10 +18,15 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
+from challenges.views import InviteCodeJoinView
+
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", include("accounts.urls")),
     path("challenges/", include("challenges.urls")),
     path("aiauth/", include("aiauthentications.urls")),
     path("challenges/", include("settlements.urls")),
+
+    # 초대코드 검증 엔드포인트
+    path("invites/join/", InviteCodeJoinView.as_view(), name="invite-join"),
 ]


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #50 

### ✨️ 작업 내용

- 초대코드 입력 검증 API 구현 (POST /invites/join)
- 유효하지 않거나 만료된 코드 예외 처리 (404, 410)
- 이미 참가한 경우 / 참가 가능한 경우 구분 응답 추가

### 💭 코멘트


### 📸 구현 결과

### 구현 결과

`/admin` 을 통해 관리자 페이지로 접속하면 dkfodhk rkxdl 챌린지들의 invite code를 확인 할 수 있다.

<img width="1550" height="620" alt="image" src="https://github.com/user-attachments/assets/24dd0dc3-c3e4-4555-b6cb-caf0f3458eb2" />

위에서 확인한 초대코드를 요청 body로 보내면, 아래와 같이 정상적으로 200응답을 확인 할 수 있다.

<img width="1609" height="969" alt="image" src="https://github.com/user-attachments/assets/b2e56e79-7af7-4f02-bc81-7d89f7fa9842" />

그러나 유효하지 않은 코드를 보내면, 아래와 같이 404 응답을 확인 할 수 있다.

<img width="829" height="728" alt="image" src="https://github.com/user-attachments/assets/6fc1d4ce-2078-4786-be31-ab641bd23014" />
