### PR TITLE
[Fix] 챌린지 상세 조회에 freq_n_days 및 누락 필드 반영

### DIFF
--- a/challenges/serializers.py
+++ b/challenges/serializers.py
@@ -148,7 +148,7 @@ class ChallengeDetailForGuestSerializer(serializers.ModelSerializer):
         model = Challenge
         fields = (
             "id", "title", "owner_name", "cover_image",
-            "entry_fee", "duration_weeks", "freq_type",
+            "entry_fee", "duration_weeks", "freq_type", "freq_n_days",
             "subtitle", "ai_condition", "category",
             "status", "start_date", "end_date",
             "member_count", "member_limit",
@@ -215,6 +215,7 @@ class ChallengeDetailForMemberSerializer(serializers.Serializer):
     entry_fee = serializers.IntegerField()
     duration_weeks = serializers.IntegerField()
     freq_type = serializers.CharField()
+    freq_n_days = serializers.IntegerField(allow_null=True)
     category = CategoryMiniOut()
     status = serializers.CharField()
     start_date = serializers.DateField(allow_null=True)

--- a/challenges/views.py
+++ b/challenges/views.py
@@ -409,6 +409,7 @@ class ChallengeDetailView(GenericAPIView):
             "entry_fee": challenge.entry_fee,
             "duration_weeks": challenge.duration_weeks,
             "freq_type": challenge.freq_type,
+            "freq_n_days": challenge.freq_n_days,
             "category": {"id": challenge.category_id, "name": challenge.category.name if challenge.category else None},
             "status": challenge.status,
             "start_date": challenge.start_date,


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #67 

### ✨️ 작업 내용

/challenges/{id}/ 응답에서 freq_n_days가 누락된 것 추가
-  ChallengeDetailForGuestSerializer에 freq_n_days 추가
-  ChallengeDetailForMemberSerializer에 freq_n_days 추가
-  ChallengeDetailView의 참여중 payload에 freq_n_days 포함


### 📸 구현 결과

<img width="1278" height="1376" alt="image" src="https://github.com/user-attachments/assets/9c47e611-d78e-4325-9e1d-4266e3e4381b" />